### PR TITLE
reconcile expression syntax for env variables

### DIFF
--- a/lsif/lsif-go.campaign.yaml
+++ b/lsif/lsif-go.campaign.yaml
@@ -43,9 +43,8 @@ steps:
                   - name: Upload LSIF data
                     run: src lsif upload
                     env:
-                      SRC_ACCESS_TOKEN: \${{ secrets.srcAccessToken }}
-                      SRC_ENDPOINT: \${{ secrets.srcEndpoint }}
-
+                      SRC_ACCESS_TOKEN: ${{ "\\${{ secrets.srcAccessToken }}" }}
+                      SRC_ENDPOINT: ${{ "\\${{ secrets.srcEndpoint }}" }}
       EOF
         else
           cat <<EOF >>.github/workflows/lsif.yml
@@ -61,9 +60,8 @@ steps:
                     working-directory: ${root}
                     run: src lsif upload
                     env:
-                      SRC_ACCESS_TOKEN: \${{ secrets.srcAccessToken }}
-                      SRC_ENDPOINT: \${{ secrets.srcEndpoint }}
-
+                      SRC_ACCESS_TOKEN: ${{ "\\${{ secrets.srcAccessToken}}" }}
+                      SRC_ENDPOINT: ${{ "\\${{ secrets.srcEndpoint }}" }}
       EOF
         fi
       done


### PR DESCRIPTION
- current script is broken.
- this commit fixes the incorrect expression syntax provided in the SRC_ACCCESS_TOKEN and SRC_ENDPOINT env variables.
- explanation here: https://docs.sourcegraph.com/batch_changes/references/batch_spec_cheat_sheet#write-a-github-actions-workflow-that-includes-github-expression-syntax